### PR TITLE
カテゴリ削除にプロンプトを削除しないようにする対応

### DIFF
--- a/src/components/PromptBox.vue
+++ b/src/components/PromptBox.vue
@@ -5,6 +5,7 @@ import { useEventBus } from '@vueuse/core';
 import { expandTogleEventKey } from '../events';
 import PromptRow from './PromptRow.vue';
 import VuSlideUpDown from 'vue-slide-up-down';
+import { uncategorizedCategoryId } from '../constants';
 
 const props = defineProps<{
   id: string;
@@ -18,6 +19,14 @@ const icon = computed(() => (expand.value ? 'remove' : 'add'));
 function toggleExpand() {
   expand.value = !expand.value;
 }
+
+const labelClass = computed(() => {
+  const classes: string[] = [];
+  if (props.id === uncategorizedCategoryId) {
+    classes.push('uncategorized-label');
+  }
+  return classes;
+});
 
 const { on } = useEventBus(expandTogleEventKey);
 on((ev) => (expand.value = ev.expand));
@@ -41,7 +50,9 @@ const hasRecords = computed(() => filterdRecords.value.length > 0);
       <div class="material-symbols-outlined md-18 accordion-button">
         {{ icon }}
       </div>
-      <div>{{ category }}</div>
+      <div>
+        <span :class="labelClass">{{ category }}</span>
+      </div>
     </div>
     <VuSlideUpDown :active="expand" :duration="200">
       <table class="prompt-table">

--- a/src/components/controls/CategoryDialog.vue
+++ b/src/components/controls/CategoryDialog.vue
@@ -75,7 +75,10 @@ defineExpose({ modal });
         <div class="dialog">
           <h1 class="title">カテゴリ編集</h1>
           <div class="caution">
-            ※カテゴリを削除すると、カテゴリ内のプロンプトもすべて削除されます。
+            ※カテゴリを削除すると、カテゴリ内のプロンプトは<span
+              class="uncategorized-label"
+              >未分類</span
+            >カテゴリに移動します。
           </div>
           <div class="list-area">
             <CategoryDialogRecord

--- a/src/data/data-import-export.ts
+++ b/src/data/data-import-export.ts
@@ -46,7 +46,7 @@ export const importTsv = async (
 
     const mergedCategories =
       uncategorized.prompts.length > 0
-        ? [uncategorized, ...categories]
+        ? [...categories, uncategorized]
         : categories;
 
     await storeRecords(mergedCategories);

--- a/src/style.scss
+++ b/src/style.scss
@@ -95,3 +95,8 @@ body {
     color: var(--light-color);
   }
 }
+
+.uncategorized-label {
+  transform: skewX(-15deg);
+  display: inline-block;
+}


### PR DESCRIPTION
- 削除したカテゴリ内のプロンプトを未分類カテゴリに移動する処理を追加
- インポート時に「未分類」カテゴリが存在する場合は、先頭ではなく末尾に追加するよう修正
- カテゴリ編集ダイアログに「未分類」カテゴリを表示しないよう修正
- 「未分類」カテゴリのカテゴリラベル表記が斜体となるよう修正

#12 