### PR TITLE
avalab側のプロンプト入力の候補表示抑止 

### DIFF
--- a/options.html
+++ b/options.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Avalab.ai プロンプト入力ツール 動作設定</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="src/options_ui/main.ts"></script>
+  </body>
+</html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -12,6 +12,9 @@
   "action": {
     "default_popup": "popup.html"
   },
+  "options_ui": {
+    "page": "options.html"
+  },
   "content_scripts": [
     {
       "matches": ["https://avalab.ai/generate"],

--- a/src/components/edit-records/CategoryEditControl.vue
+++ b/src/components/edit-records/CategoryEditControl.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { nextTick, ref } from 'vue';
 import { useEventBus } from '@vueuse/core';
 import { CategoryRecord } from '@models/prompts/category-record';
 import { storeRecordsRef } from '@models/prompts/data-store';
@@ -50,6 +50,7 @@ on(async () => {
     newList.push(uncategorized);
   }
   model.value = newList;
+  await nextTick();
   await storeRecordsRef(model);
 });
 </script>

--- a/src/content_scripts/index.ts
+++ b/src/content_scripts/index.ts
@@ -1,3 +1,4 @@
+import { loadOptions, watchOptions } from '@models/options/data-store';
 import { PromptMessage } from '@messages/message-types';
 
 const sleep = (ms: number) =>
@@ -28,9 +29,20 @@ const isTargetButton = (node: Node): node is HTMLButtonElement => {
   return false;
 };
 
+const hideSuggest = (node: Node): void => {
+  if (!(node instanceof HTMLElement)) {
+    return;
+  }
+  if (node.classList.contains('suggest')) {
+    node.style.display = 'none';
+  }
+};
+
 async function main() {
   let input: any = undefined;
   let button: any = undefined;
+  let hideOption = (await loadOptions()).hidePromptSuggest;
+  watchOptions((options) => (hideOption = options.hidePromptSuggest));
 
   const observer = new MutationObserver((records) => {
     for (const record of records) {
@@ -40,6 +52,9 @@ async function main() {
         }
         if (isTargetButton(target)) {
           button = target;
+        }
+        if (hideOption) {
+          hideSuggest(target);
         }
       }
     }

--- a/src/models/options/data-store.ts
+++ b/src/models/options/data-store.ts
@@ -1,0 +1,26 @@
+import { Ref } from 'vue';
+import { defineLoadStore } from '@utils/storage.util';
+import { Options, optionsDefault } from './options';
+
+const APP_OPTIONS = 'APP_OPTIONS';
+
+const { load: loadOptions, store: storeOptions } = defineLoadStore<Options>(
+  APP_OPTIONS,
+  optionsDefault,
+);
+
+export { loadOptions, storeOptions };
+
+export const storeOptionsRef = async (options: Ref<Options>): Promise<void> => {
+  await storeOptions({
+    hidePromptSuggest: options.value.hidePromptSuggest,
+  });
+};
+
+export const watchOptions = (callback: (options: Options) => void) => {
+  chrome.storage.local?.onChanged.addListener((changes) => {
+    if (changes[APP_OPTIONS]) {
+      callback(changes[APP_OPTIONS].newValue);
+    }
+  });
+};

--- a/src/models/options/options.ts
+++ b/src/models/options/options.ts
@@ -1,0 +1,7 @@
+export type Options = {
+  hidePromptSuggest: boolean;
+};
+
+export const optionsDefault: Options = {
+  hidePromptSuggest: false,
+};

--- a/src/models/prompts/data-store.ts
+++ b/src/models/prompts/data-store.ts
@@ -1,24 +1,17 @@
 import { Ref } from 'vue';
+import { defineLoadStore } from '@utils/storage.util';
 import { CategoryRecord } from './category-record';
 import { initialData } from './initial-data';
 
-const RECORDS_KEY = 'CATEGORY_DATA';
-
-export const loadRecords = async (): Promise<CategoryRecord[]> => {
-  const data = await chrome.storage?.local.get(RECORDS_KEY);
-  const records = data ? data[RECORDS_KEY] : undefined;
-  return records ?? initialData;
-};
-
-export const storeRecords = async (data: CategoryRecord[]): Promise<void> => {
-  const obj: { [key: string]: any } = {};
-  obj[RECORDS_KEY] = data;
-  await chrome.storage?.local.set(obj);
-};
+const { load: loadRecords, store: storeRecords } = defineLoadStore<
+  CategoryRecord[]
+>('CATEGORY_DATA', initialData);
+export { loadRecords, storeRecords };
 
 export const storeRecordsRef = async (
   data: Ref<CategoryRecord[]>,
 ): Promise<void> => {
+  console.log(data.value);
   const list: CategoryRecord[] = data.value.map((val) => ({
     id: val.id,
     name: val.name,
@@ -28,5 +21,6 @@ export const storeRecordsRef = async (
       description: p.description,
     })),
   }));
+  console.log(list);
   await storeRecords(list);
 };

--- a/src/options_ui/App.vue
+++ b/src/options_ui/App.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue';
+import { useDebounceFn } from '@vueuse/core';
+import { loadOptions, storeOptionsRef } from '@models/options/data-store';
+import { Options, optionsDefault } from '@models/options/options';
+
+const options = ref<Options>(optionsDefault);
+onMounted(async () => {
+  options.value = await loadOptions();
+});
+
+watch(
+  options,
+  useDebounceFn(
+    async () => {
+      await storeOptionsRef(options);
+    },
+    50,
+    { maxWait: 500 },
+  ),
+  { deep: true },
+);
+</script>
+
+<template>
+  <div class="main">
+    <div class="item">
+      <input
+        type="checkbox"
+        id="hide-prompt-suggest"
+        v-model="options.hidePromptSuggest"
+      /><label for="hide-prompt-suggest"
+        >Avalab.aiのプロンプト入力候補を表示しない</label
+      >
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.main {
+  margin: 1rem;
+}
+.item {
+  margin: 1rem;
+}
+</style>

--- a/src/options_ui/main.ts
+++ b/src/options_ui/main.ts
@@ -1,0 +1,17 @@
+import { createApp } from 'vue';
+import FloatingVue from 'floating-vue';
+import 'floating-vue/dist/style.css';
+import '@css/style.scss';
+import App from './App.vue';
+import './options.scss';
+
+const app = createApp(App);
+app.use(FloatingVue, {
+  themes: {
+    'info-tooltip': {
+      distance: 24,
+      delay: { show: 1000, hide: 0 },
+    },
+  },
+});
+app.mount('#app');

--- a/src/options_ui/options.scss
+++ b/src/options_ui/options.scss
@@ -1,0 +1,12 @@
+body {
+  margin: 0;
+  width: 600px;
+}
+
+#app {
+  margin: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}

--- a/src/utils/storage.util.ts
+++ b/src/utils/storage.util.ts
@@ -1,0 +1,22 @@
+export const defineLoadStore = <T>(
+  storageKey: string,
+  initialData: T,
+): {
+  load: () => Promise<T>;
+  store: (data: T) => Promise<void>;
+} => {
+  const load = async () => {
+    const data = await chrome.storage?.local.get(storageKey);
+    const options = data ? data[storageKey] : undefined;
+    return options ?? initialData;
+  };
+  const store = async (data: T) => {
+    const obj: { [key: string]: any } = {};
+    obj[storageKey] = data;
+    console.log('start set', data);
+    await chrome.storage?.local.set(obj);
+    console.log('end set', data);
+  };
+
+  return { load, store };
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     rollupOptions: {
       input: {
         popup: resolve(__dirname, 'popup.html'),
+        options: resolve(__dirname, 'options.html'),
       },
     },
   },


### PR DESCRIPTION
- コンテンツスクリプトにプロンプト候補の表示抑止処理を追加
- オプション画面とオプションの保存処理を実装
- カテゴリの並べ替え結果が保存されないバグを修正（ #23 で混入）
- chrome.storage.localへのアクセス処理を共通化

 #14